### PR TITLE
Add some variables to make the module idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "okta" {
 
 ### Login via the CLI
 
-Login either via the UI or the CLI. If you want to get a local vault token, you'll need to run the following command, which will spin up a listener process by default on port 8250. You can override this with `port=xxx` in this command but you'll need to also update the redirect URIs in Okta and add the `cli_port` terraform variable. 
+Login either via the UI or the CLI. If you want to get a local vault token, you'll need to run the following command, which will spin up a listener process by default on port 8250. You can override this with `port=xxx` in this command but you'll need to also update the redirect URIs in Okta and add the `cli_port` terraform variable.
 
 ```
 vault login -method=oidc -path=okta_oidc role=okta-admin
@@ -174,6 +174,9 @@ terraform apply
 | okta\_allowed\_groups | Okta group for Vault admins | `list` | <pre>[<br>  "vault_admins"<br>]<br></pre> | no |
 | okta\_mount\_path | Mount path for Okta auth | `string` | `"okta_oidc"` | no |
 | roles | Map of Vault role names to their bound groups and token policies. Structure looks like this:<pre>roles = {<br>  okta_admin = {<br>    token_policies = ["admin"]<br>    bound_groups = ["vault_admins"]<br>  },<br>  okta_devs  = {<br>    token_policies = ["devs"]<br>    bound_groups = ["vault_devs"]<br>  }<br>}<br></pre> | `map` | `{}` | no |
+| okta\_default\_lease\_ttl | Default lease TTL for Vault tokens | `string` | `"768h"` | no |
+| okta\_max\_lease\_ttl | Maximum lease TTL for Vault tokens | `string` | `"768h"` | no |
+| okta\_token\_type | Token type for Vault tokens | `string` | `"default-service"` | no |
 
 ## Outputs
 
@@ -181,4 +184,3 @@ terraform apply
 |------|-------------|
 | path | Okta OIDC auth path |
 | roles | Role names created by this module |
-

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,9 @@ resource "vault_jwt_auth_backend" "okta_oidc" {
   oidc_client_secret = var.okta_client_secret
   tune {
     listing_visibility = "unauth"
+    default_lease_ttl  = var.okta_default_lease_ttl
+    max_lease_ttl      = var.okta_max_lease_ttl
+    token_type         = var.okta_token_type
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,24 @@ variable "cli_port" {
   default     = 8250
 }
 
+variable "okta_default_lease_ttl" {
+  type        = string
+  description = "Default lease TTL for Vault tokens"
+  default     = "768h"
+}
+
+variable "okta_max_lease_ttl" {
+  type        = string
+  description = "Maximum lease TTL for Vault tokens"
+  default     = "768h"
+}
+
+variable "okta_token_type" {
+  type        = string
+  description = "Token type for Vault tokens"
+  default     = "default-service"
+}
+
 variable "roles" {
   type    = map
   default = {}


### PR DESCRIPTION
I've added 3 variables that are being set by vault by default, but cause a change with regard to terraform state.

It prevents a situation like this on subsequent runs:
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.okta.vault_jwt_auth_backend.okta_oidc will be updated in-place
  ~ resource "vault_jwt_auth_backend" "okta_oidc" {
        id                     = "okta_oidc"
      ~ tune                   = [
          + {
              + allowed_response_headers     = []
              + audit_non_hmac_request_keys  = []
              + audit_non_hmac_response_keys = []
              + default_lease_ttl            = ""
              + listing_visibility           = "unauth"
              + max_lease_ttl                = ""
              + passthrough_request_headers  = []
              + token_type                   = ""
            },
          - {
              - allowed_response_headers     = []
              - audit_non_hmac_request_keys  = []
              - audit_non_hmac_response_keys = []
              - default_lease_ttl            = "768h"
              - listing_visibility           = "unauth"
              - max_lease_ttl                = "768h"
              - passthrough_request_headers  = []
              - token_type                   = "default-service"
            },
        ]
        # (11 unchanged attributes hidden)
    }
```

I regenerated the docs, it seems the format changed a bit since the last time it was used in this repository, but fixing that might be beyond the scope of this PR...