### PR TITLE
Update version this module supports

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12"
+  required_version = ">= 0.12"
   required_providers {
     vault = "~> 2.11"
   }


### PR DESCRIPTION
Didn't actually mean to create it here, but let's call it a happy accident.

Terraform version 1.0.2 is out, and I see no reason why this module wouldn't work with it.